### PR TITLE
Fix null CKEditor email config handling

### DIFF
--- a/src/behaviors/MessageBehavior.php
+++ b/src/behaviors/MessageBehavior.php
@@ -48,7 +48,7 @@ class MessageBehavior extends Behavior
             'handle' => 'body',
         ];
         if (Emails::$plugin->ckeditor->isVersionAtLeast5()) {
-            $config = array_merge($config, $email->ckeConfigJson);
+            $config = array_merge($config, is_array($email->ckeConfigJson) ? $email->ckeConfigJson : []);
         } else {
             try {
                 Plugin::getInstance()->ckeConfigs->getByUid($email->ckeConfig ?? '');

--- a/src/models/Email.php
+++ b/src/models/Email.php
@@ -35,6 +35,12 @@ class Email extends Model
     public $fromName;
     public $replyTo;
 
+    public function init(): void
+    {
+        parent::init();
+        $this->normalizeCkeConfigJson();
+    }
+
     /**
      * @inheritDoc
      */
@@ -109,6 +115,7 @@ class Email extends Model
                 $this->$attribute = $value;
             }
         }
+        $this->normalizeCkeConfigJson();
     }
 
     /**
@@ -186,5 +193,18 @@ class Email extends Model
         }
         asort($languages);
         return $languages;
+    }
+
+    protected function normalizeCkeConfigJson(): void
+    {
+        if (is_string($this->ckeConfigJson)) {
+            $decoded = json_decode($this->ckeConfigJson, true);
+            $this->ckeConfigJson = is_array($decoded) ? $decoded : [];
+            return;
+        }
+
+        if (!is_array($this->ckeConfigJson)) {
+            $this->ckeConfigJson = [];
+        }
     }
 }

--- a/src/templates/_includes/ckeditor-config.twig
+++ b/src/templates/_includes/ckeditor-config.twig
@@ -1,6 +1,8 @@
 {% import '_includes/forms.twig' as forms %}
 {% import 'codeeditor/codeEditor.twig' as codeEditor %}
 
+{% set ckeConfigJson = email.ckeConfigJson ?? [] %}
+
 {% namespace 'ckeConfigJson' %}
     {% embed '_includes/forms/field.twig' with {
     label: 'Toolbar'|t('ckeditor'),
@@ -27,7 +29,7 @@
                 </div>
             </div>
             </div>
-            {{ hiddenInput('toolbar', (email.ckeConfigJson.toolbar ?? [])|json_encode) }}
+            {{ hiddenInput('toolbar', (ckeConfigJson.toolbar ?? [])|json_encode) }}
         </div>
         {% endblock %}
     {% endembed %}
@@ -38,7 +40,7 @@
     showUnused: false,
     } %}
     {% set baseCodeEditorOptions = {} %}
-    {% set lang = email.ckeConfigJson.js ? 'js' : 'json' %}
+    {% set lang = ckeConfigJson.js ?? false ? 'js' : 'json' %}
     {% set isJson = lang == 'json' %}
     {% set isJs = lang == 'js' %}
 
@@ -67,7 +69,7 @@
             {label: 'Heading {level}'|t('ckeditor', {level: 5}), value: '5'},
             {label: 'Heading {level}'|t('ckeditor', {level: 6}), value: '6'},
         ],
-        values: email.ckeConfigJson.headingLevels ?? [],
+        values: ckeConfigJson.headingLevels ?? [],
     }) }}
 
     {{ forms.checkboxSelectField({
@@ -76,7 +78,7 @@
         name: 'advancedLinkFields',
         showAllOption: false,
         options: advanceLinkOptions,
-        values: email.ckeConfigJson.advancedLinkFields ?? [],
+        values: ckeConfigJson.advancedLinkFields ?? [],
         sortable: true,
     }) }}
 
@@ -84,7 +86,7 @@
         id: 'show-word-count',
         name: 'showWordCount',
         label: 'Show word count'|t('ckeditor'),
-        on: email.ckeConfigJson.showWordCount ?? false,
+        on: ckeConfigJson.showWordCount ?? false,
     }) }}
 
     {% embed '_includes/forms/field.twig' with {
@@ -212,7 +214,7 @@
         label: 'Available Volumes'|t('ckeditor'),
         instructions: 'The volumes that should be available when selecting assets.'|t('ckeditor'),
         options: volumeOptions,
-        values: email.ckeConfigJson.availableVolumes ?? [],
+        values: ckeConfigJson.availableVolumes ?? [],
         showAllOption: volumeOptions|length ? true : false,
     }) }}
 
@@ -221,7 +223,7 @@
         instructions: 'Whether to show volumes that the user doesn’t have permission to view.'|t('ckeditor'),
         id: 'showUnpermittedVolumes',
         name: 'showUnpermittedVolumes',
-        on: email.ckeConfigJson.showUnpermittedVolumes ?? false,
+        on: ckeConfigJson.showUnpermittedVolumes ?? false,
     }) }}
 
     {{ forms.lightswitchField({
@@ -229,7 +231,7 @@
         instructions: 'Whether to show files that the user doesn’t have permission to view, per the “View files uploaded by other users” permission.'|t('ckeditor'),
         id: 'showUnpermittedFiles',
         name: 'showUnpermittedFiles',
-        on: email.ckeConfigJson.showUnpermittedFiles ?? false,
+        on: ckeConfigJson.showUnpermittedFiles ?? false,
     }) }}
 
     {% embed '_includes/forms/field.twig' with {
@@ -241,7 +243,7 @@
             <label class="nowrap">
             <img class="mb-xs" src="{{ baseIconsUrl }}/img.svg" width="80" height="60" alt="">
             {{ input('radio', 'imageMode', 'img', {
-                checked: (email.ckeConfigJson.imageMode ?? 'img') == 'img',
+                checked: (ckeConfigJson.imageMode ?? 'img') == 'img',
                 class: 'fieldtoggle',
                 data: {'target-prefix': 'image-mode--'},
             }) }}
@@ -250,7 +252,7 @@
             <label class="nowrap">
             <img class="mb-xs" src="{{ baseIconsUrl }}/entries.svg" width="80" height="60" alt="">
             {{ input('radio', 'imageMode', 'entries', {
-                checked: (email.ckeConfigJson.imageMode ?? 'img') == 'entries',
+                checked: (ckeConfigJson.imageMode ?? 'img') == 'entries',
                 class: 'fieldtoggle',
                 data: {'target-prefix': 'image-mode--'},
             }) }}
@@ -262,7 +264,7 @@
 
     {% tag 'div' with {
         id: 'image-mode--img',
-        class: (email.ckeConfigJson.imageMode ?? 'img') != 'img' ? 'hidden' : null,
+        class: (ckeConfigJson.imageMode ?? 'img') != 'img' ? 'hidden' : null,
     } %}
         {% embed '_includes/forms/field.twig' with {
             id: 'default-upload-location',
@@ -283,15 +285,15 @@
                     },
                     ...volumeOptions,
                     ],
-                    value: email.ckeConfigJson.defaultUploadLocationVolume ?? '',
+                    value: ckeConfigJson.defaultUploadLocationVolume ?? '',
                 }) }}
                 </div>
-                <div id="default-upload-location-subpath-container" class="flex-grow {{ not (email.ckeConfigJson.defaultUploadLocationVolume ?? '') ? 'hidden' }}">
+                <div id="default-upload-location-subpath-container" class="flex-grow {{ not (ckeConfigJson.defaultUploadLocationVolume ?? '') ? 'hidden' }}">
                 {{ forms.text({
                     class: 'ltr',
                     id: "default-upload-location-subpath",
                     name: "defaultUploadLocationSubpath",
-                    value: email.ckeConfigJson.defaultUploadLocationSubpath ?? '',
+                    value: ckeConfigJson.defaultUploadLocationSubpath ?? '',
                     placeholder: "path/to/subfolder"|t('app'),
                 }) }}
                 </div>
@@ -305,7 +307,7 @@
         label: 'Available Transforms'|t('ckeditor'),
         instructions: 'The transforms that should be available when inserting images.'|t('ckeditor'),
         options: transformOptions,
-        values: email.ckeConfigJson.availableTransforms ?? [],
+        values: ckeConfigJson.availableTransforms ?? [],
         showAllOption: transformOptions|length ? true : false,
         }) }}
 
@@ -315,13 +317,13 @@
         label: 'Default Transform'|t('ckeditor'),
         instructions: 'The default transform that should be applied when inserting an image.'|t('ckeditor'),
         options: defaultTransformOptions,
-        value: email.ckeConfigJson.defaultTransform ?? '',
+        value: ckeConfigJson.defaultTransform ?? '',
         }) }}
     {% endtag %}
 
     {% tag 'div' with {
         id: 'image-mode--entries',
-        class: (email.ckeConfigJson.imageMode ?? 'img') != 'entries' ? 'hidden' : null,
+        class: (ckeConfigJson.imageMode ?? 'img') != 'entries' ? 'hidden' : null,
     } %}
         {% include 'ckeditor/_image-field-select.twig' with {
             field: email,


### PR DESCRIPTION
Fixes a crash when `ckeConfigJson` is null in the email editor.

## Problem
The plugin assumed `email.ckeConfigJson` was always an array.
Older or migrated records could contain `null`, which caused:
- Twig error when reading `email.ckeConfigJson.js`
- PHP error risk when merging CKEditor config

## Fix
- Normalize `ckeConfigJson` to an array in the email model
- Add a Twig fallback before reading config keys
- Guard `array_merge()` against non-array values

## Testing
- Open an email config that previously crashed
- Confirm the page loads without Twig errors
- Confirm CKEditor config fields render
- Save and reopen the email successfully